### PR TITLE
fix: possible prototype pollution vulnerability

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -14,7 +14,7 @@ export function createRouter<T extends RadixNodeData = RadixNodeData>(
     const ctx: RadixRouterContext = {
         options,
         rootNode: createRadixNode(),
-        staticRoutesMap: {},
+        staticRoutesMap: Object.create(null),
         funcs: options.funcs || {},
         parseParameters:
             typeof options.parseParameters === 'boolean'


### PR DESCRIPTION
## 🚨 Proposed changes
I converted the classic obj into an obj with null prototype to avoid possible prototype pollution vulnerabilities.
It should not be vulnerable also with an obj with the prototype, but I feel more confident about adding it than not.

## ⚙️ Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation Update (if none of the other choices apply)
-   [ ] Refactor
